### PR TITLE
LocalChanges view: staged & unstaged file lists

### DIFF
--- a/GitGui/CommitDetailsView.cs
+++ b/GitGui/CommitDetailsView.cs
@@ -67,7 +67,7 @@ public sealed class CommitDetailsView : MultiChildView
     public CommitDetailsView()
     {
         _content = new ColumnView { Gap = 8 };
-        var paddedContent = new RectView
+        var paddedContent = new PaddingView
         {
             Padding = new PaddingStyle { Left = Padding, Right = Padding, Top = Padding, Bottom = Padding },
             Children = { _content },

--- a/GitGui/CommitDetailsView.cs
+++ b/GitGui/CommitDetailsView.cs
@@ -8,18 +8,10 @@ internal static class CommitDetailsPalette
 {
     public const uint Background = 0xFF1A1B1E;
     public const uint Border = 0xFF313338;
-    public const uint SectionBg = 0xFF222326;
-    public const uint Heading = 0xFF96989D;
     public const uint Primary = 0xFFE6E6E6;
     public const uint Secondary = 0xFFB5B9C0;
     public const uint Muted = 0xFF7A7C81;
     public const uint Placeholder = 0xFF96989D;
-
-    public const uint StatusAdded = 0xFF57F287;
-    public const uint StatusModified = 0xFFE9C77A;
-    public const uint StatusDeleted = 0xFFED4245;
-    public const uint StatusRenamed = 0xFF5DADE2;
-    public const uint StatusOther = 0xFF9B59B6;
 
     private static readonly uint[] AvatarPalette =
     {
@@ -55,7 +47,6 @@ public sealed class CommitDetailsView : MultiChildView
 {
     private const int Padding = 14;
     private const float AvatarSize = 36f;
-    private const float StatusBadgeSize = 16f;
 
     private IMessageBus? _bus;
     private IGitService? _gitService;
@@ -315,14 +306,10 @@ public sealed class CommitDetailsView : MultiChildView
             TextColor = CommitDetailsPalette.Muted,
         });
 
-        // Files header bar
-        _content.Children.Add(BuildFilesHeader(d.Files.Count));
-
-        // File rows
-        foreach (var file in d.Files)
-        {
-            _content.Children.Add(BuildFileRow(file));
-        }
+        // Changed files
+        var section = new FileChangesSection("Changes");
+        section.SetFiles(d.Files);
+        _content.Children.Add(section);
 
         _scrollPane.ScrollToOrigin();
     }
@@ -379,77 +366,6 @@ public sealed class CommitDetailsView : MultiChildView
         };
     }
 
-    private static View BuildFilesHeader(int count)
-    {
-        return new RectView
-        {
-            BackgroundColor = CommitDetailsPalette.SectionBg,
-            BorderColor = new BorderColorStyle
-            {
-                Top = CommitDetailsPalette.Border,
-                Bottom = CommitDetailsPalette.Border,
-            },
-            BorderSize = new BorderSizeStyle { Top = 1, Bottom = 1 },
-            Padding = new PaddingStyle { Left = 4, Right = 4, Top = 4, Bottom = 4 },
-            Children =
-            {
-                new TextView
-                {
-                    Text = $"Changes ({count})",
-                    TextColor = CommitDetailsPalette.Heading,
-                },
-            },
-        };
-    }
-
-    private static View BuildFileRow(FileChange file)
-    {
-        var color = file.Status switch
-        {
-            FileChangeStatus.Added => CommitDetailsPalette.StatusAdded,
-            FileChangeStatus.Modified => CommitDetailsPalette.StatusModified,
-            FileChangeStatus.Deleted => CommitDetailsPalette.StatusDeleted,
-            FileChangeStatus.Renamed => CommitDetailsPalette.StatusRenamed,
-            _ => CommitDetailsPalette.StatusOther,
-        };
-
-        var badge = new RectView
-        {
-            PreferredWidth = StatusBadgeSize,
-            PreferredHeight = StatusBadgeSize,
-            BackgroundColor = color,
-            BorderRadius = BorderRadiusStyle.All(3),
-            Children =
-            {
-                new TextView
-                {
-                    Text = StatusGlyph(file.Status),
-                    TextColor = 0xFF1A1B1E,
-                    FontSize = 11f,
-                    HorizontalTextAlignment = TextAlignment.Center,
-                    VerticalTextAlignment = TextAlignment.Center,
-                },
-            },
-        };
-
-        var path = new TextView
-        {
-            Text = FormatPath(file),
-            TextColor = CommitDetailsPalette.Secondary,
-        };
-
-        return new FlexRowView
-        {
-            Gap = 8f,
-            CrossAxisAlignment = CrossAxisAlignment.Start,
-            Children =
-            {
-                badge,
-                new FlexItem { Grow = 1, Child = path },
-            },
-        };
-    }
-
     private static string Initials(string name, string email)
     {
         var source = !string.IsNullOrWhiteSpace(name) ? name : email;
@@ -475,24 +391,6 @@ public sealed class CommitDetailsView : MultiChildView
 
     private static string ShortSha(string sha)
         => string.IsNullOrEmpty(sha) ? string.Empty : (sha.Length >= 7 ? sha[..7] : sha);
-
-    private static string StatusGlyph(FileChangeStatus status) => status switch
-    {
-        FileChangeStatus.Added => "A",
-        FileChangeStatus.Modified => "M",
-        FileChangeStatus.Deleted => "D",
-        FileChangeStatus.Renamed => "R",
-        FileChangeStatus.Copied => "C",
-        FileChangeStatus.TypeChanged => "T",
-        _ => "·",
-    };
-
-    private static string FormatPath(FileChange file)
-    {
-        if (file.Status == FileChangeStatus.Renamed && !string.IsNullOrEmpty(file.OldPath))
-            return $"{file.OldPath} → {file.Path}";
-        return file.Path;
-    }
 
     /// <summary>
     /// libgit2's Message includes the subject line. Extract the body (everything after the

--- a/GitGui/CommitDetailsView.cs
+++ b/GitGui/CommitDetailsView.cs
@@ -1,6 +1,7 @@
 using ZGF.Gui;
 using ZGF.Gui.Layouts;
 using ZGF.Gui.Tests;
+using ZGF.Observable;
 
 namespace GitGui;
 
@@ -35,12 +36,10 @@ internal static class CommitDetailsPalette
     }
 }
 
-internal enum CommitDetailsState
+internal abstract record CommitDetailsViewModel
 {
-    Empty,
-    Loading,
-    Loaded,
-    Error,
+    public sealed record Placeholder(string Text) : CommitDetailsViewModel;
+    public sealed record Loaded(CommitDetails Details) : CommitDetailsViewModel;
 }
 
 public sealed class CommitDetailsView : MultiChildView
@@ -51,15 +50,14 @@ public sealed class CommitDetailsView : MultiChildView
     private IMessageBus? _bus;
     private IGitService? _gitService;
     private IRepoRegistry? _registry;
+    private IUiDispatcher? _dispatcher;
     private Action<CommitSelectedMessage>? _selectedHandler;
+    private IDisposable? _vmSubscription;
 
-    private CommitDetailsState _state = CommitDetailsState.Empty;
-    private CommitDetails? _details;
-    private CommitDetails? _pendingDetails;
-    private string? _pendingErrorMessage;
+    private readonly State<CommitDetailsViewModel> _viewModel = new(
+        new CommitDetailsViewModel.Placeholder("Select a commit to view details."));
+
     private int _loadGeneration;
-    private string? _requestedSha;
-    private Guid _requestedRepoId;
 
     private readonly ColumnView _content;
     private readonly ScrollPane _scrollPane;
@@ -126,8 +124,6 @@ public sealed class CommitDetailsView : MultiChildView
         });
 
         Behaviors.Add(new CommitDetailsScrollSyncController(_scrollPane, _vScrollBar, _hScrollBar));
-
-        ShowPlaceholder("Select a commit to view details.");
     }
 
     private static void StyleScrollBarThumb(VerticalScrollBarThumbView thumb)
@@ -163,6 +159,8 @@ public sealed class CommitDetailsView : MultiChildView
         _bus = context.Get<IMessageBus>();
         _gitService = context.Get<IGitService>();
         _registry = context.Get<IRepoRegistry>();
+        _dispatcher = context.Get<IUiDispatcher>();
+        _vmSubscription = _viewModel.Subscribe(Render);
         if (_bus != null)
         {
             _selectedHandler = OnCommitSelected;
@@ -172,14 +170,18 @@ public sealed class CommitDetailsView : MultiChildView
 
     protected override void OnDetachedFromContext(Context context)
     {
+        _loadGeneration++;
         if (_bus != null && _selectedHandler != null)
         {
             _bus.Unsubscribe(_selectedHandler);
         }
+        _vmSubscription?.Dispose();
+        _vmSubscription = null;
         _selectedHandler = null;
         _bus = null;
         _gitService = null;
         _registry = null;
+        _dispatcher = null;
     }
 
     private void OnCommitSelected(CommitSelectedMessage msg)
@@ -187,10 +189,7 @@ public sealed class CommitDetailsView : MultiChildView
         if (string.IsNullOrEmpty(msg.Sha))
         {
             _loadGeneration++;
-            _requestedSha = null;
-            _state = CommitDetailsState.Empty;
-            _details = null;
-            ShowPlaceholder("Select a commit to view details.");
+            _viewModel.Value = new CommitDetailsViewModel.Placeholder("Select a commit to view details.");
             return;
         }
         StartLoad(msg.RepoId, msg.Sha);
@@ -204,53 +203,44 @@ public sealed class CommitDetailsView : MultiChildView
 
         _loadGeneration++;
         var gen = _loadGeneration;
-        _requestedSha = sha;
-        _requestedRepoId = repoId;
-        _state = CommitDetailsState.Loading;
-        _details = null;
-        ShowPlaceholder("Loading…");
+        _viewModel.Value = new CommitDetailsViewModel.Placeholder("Loading…");
 
         var service = _gitService;
+        var dispatcher = _dispatcher;
         Task.Run(() =>
         {
+            CommitDetailsViewModel result;
             try
             {
                 var details = service.LoadDetails(repo, sha);
-                if (gen != Volatile.Read(ref _loadGeneration)) return;
-                Volatile.Write(ref _pendingDetails, details);
+                result = details.ErrorMessage != null
+                    ? new CommitDetailsViewModel.Placeholder(details.ErrorMessage)
+                    : new CommitDetailsViewModel.Loaded(details);
             }
             catch (Exception ex)
             {
-                if (gen != Volatile.Read(ref _loadGeneration)) return;
-                Volatile.Write(ref _pendingErrorMessage, ex.Message);
+                result = new CommitDetailsViewModel.Placeholder(ex.Message);
             }
+
+            dispatcher?.Post(() =>
+            {
+                if (gen != _loadGeneration) return;
+                _viewModel.Value = result;
+            });
         });
     }
 
-    protected override void OnDrawSelf(ICanvas c)
+    private void Render(CommitDetailsViewModel vm)
     {
-        PollPending();
-    }
-
-    private void PollPending()
-    {
-        var err = Interlocked.Exchange(ref _pendingErrorMessage, null);
-        if (err != null)
+        switch (vm)
         {
-            _details = null;
-            _state = CommitDetailsState.Error;
-            ShowPlaceholder(err);
+            case CommitDetailsViewModel.Placeholder p:
+                ShowPlaceholder(p.Text);
+                break;
+            case CommitDetailsViewModel.Loaded l:
+                ShowDetails(l.Details);
+                break;
         }
-
-        var pending = Interlocked.Exchange(ref _pendingDetails, null);
-        if (pending == null) return;
-        if (pending.Sha != _requestedSha || pending.RepoId != _requestedRepoId) return;
-        _details = pending;
-        _state = pending.ErrorMessage != null ? CommitDetailsState.Error : CommitDetailsState.Loaded;
-        if (_state == CommitDetailsState.Error)
-            ShowPlaceholder(pending.ErrorMessage ?? "Error.");
-        else
-            ShowDetails(pending);
     }
 
     private void ShowPlaceholder(string text)

--- a/GitGui/CommitsView.cs
+++ b/GitGui/CommitsView.cs
@@ -1,6 +1,7 @@
 using ZGF.Geometry;
 using ZGF.Gui;
 using ZGF.Gui.Tests;
+using ZGF.Observable;
 
 namespace GitGui;
 
@@ -90,11 +91,11 @@ public sealed class CommitsView : MultiChildView
     private IMessageBus? _bus;
     private IRepoRegistry? _registry;
     private IGitService? _gitService;
+    private IUiDispatcher? _dispatcher;
     private IDisposable? _activeSubscription;
 
     private CommitsLoadState _state = CommitsLoadState.NoRepo;
     private CommitSnapshot? _snapshot;
-    private CommitSnapshot? _pendingSnapshot;
     private int _loadGeneration;
     private Guid _loadingRepoId;
 
@@ -159,6 +160,7 @@ public sealed class CommitsView : MultiChildView
         _bus = context.Get<IMessageBus>();
         _registry = context.Get<IRepoRegistry>();
         _gitService = context.Get<IGitService>();
+        _dispatcher = context.Get<IUiDispatcher>();
         if (_registry != null)
         {
             _activeSubscription = _registry.Active.Subscribe(_ => StartLoadForActiveRepo());
@@ -167,11 +169,13 @@ public sealed class CommitsView : MultiChildView
 
     protected override void OnDetachedFromContext(Context context)
     {
+        _loadGeneration++;
         _activeSubscription?.Dispose();
         _activeSubscription = null;
         _bus = null;
         _registry = null;
         _gitService = null;
+        _dispatcher = null;
     }
 
     private void StartLoadForActiveRepo()
@@ -211,39 +215,41 @@ public sealed class CommitsView : MultiChildView
 
         var repo = active;
         var service = _gitService;
+        var dispatcher = _dispatcher;
         Task.Run(() =>
         {
+            CommitSnapshot snap;
             try
             {
-                var snap = service.Load(repo, 3000);
-                if (gen != Volatile.Read(ref _loadGeneration)) return;
-                Volatile.Write(ref _pendingSnapshot, snap);
+                snap = service.Load(repo, 3000);
             }
             catch (Exception ex)
             {
-                if (gen != Volatile.Read(ref _loadGeneration)) return;
-                Volatile.Write(ref _pendingSnapshot,
-                    new CommitSnapshot(repo.Id, repo.Path, Array.Empty<CommitNode>(), 0, false, ex.Message));
+                snap = new CommitSnapshot(repo.Id, repo.Path, Array.Empty<CommitNode>(), 0, false, ex.Message);
             }
+
+            dispatcher?.Post(() =>
+            {
+                if (gen != _loadGeneration) return;
+                ApplyLoadedSnapshot(snap);
+            });
         });
     }
 
     public bool Truncated => _snapshot?.Truncated == true;
     public event Action<bool>? TruncatedChanged;
 
-    private void PollPending()
+    private void ApplyLoadedSnapshot(CommitSnapshot snap)
     {
-        var pending = Interlocked.Exchange(ref _pendingSnapshot, null);
-        if (pending == null) return;
-        if (pending.RepoId != _loadingRepoId) return;
+        if (snap.RepoId != _loadingRepoId) return;
         var wasTruncated = Truncated;
-        _snapshot = pending;
-        _state = pending.ErrorMessage != null ? CommitsLoadState.Error : CommitsLoadState.Loaded;
+        _snapshot = snap;
+        _state = snap.ErrorMessage != null ? CommitsLoadState.Error : CommitsLoadState.Loaded;
         _scrollY = 0f;
         NotifyScrollChanged();
         if (wasTruncated != Truncated)
             TruncatedChanged?.Invoke(Truncated);
-        _bus?.Broadcast(new CommitsLoadedMessage(pending.RepoId));
+        _bus?.Broadcast(new CommitsLoadedMessage(snap.RepoId));
     }
 
     public float Scale
@@ -305,8 +311,6 @@ public sealed class CommitsView : MultiChildView
 
     protected override void OnDrawSelf(ICanvas c)
     {
-        PollPending();
-
         var pos = Position;
         var z = GetDrawZIndex();
 

--- a/GitGui/FileChangeRowView.cs
+++ b/GitGui/FileChangeRowView.cs
@@ -1,0 +1,96 @@
+using ZGF.Gui;
+using ZGF.Gui.Layouts;
+
+namespace GitGui;
+
+internal static class FileChangesPalette
+{
+    public const uint StatusAdded = 0xFF57F287;
+    public const uint StatusModified = 0xFFE9C77A;
+    public const uint StatusDeleted = 0xFFED4245;
+    public const uint StatusRenamed = 0xFF5DADE2;
+    public const uint StatusOther = 0xFF9B59B6;
+
+    public const uint BadgeText = 0xFF1A1B1E;
+    public const uint RowText = 0xFFB5B9C0;
+
+    public const uint HeaderBg = 0xFF222326;
+    public const uint HeaderBorder = 0xFF313338;
+    public const uint HeaderText = 0xFF96989D;
+
+    public static uint StatusColor(FileChangeStatus status) => status switch
+    {
+        FileChangeStatus.Added => StatusAdded,
+        FileChangeStatus.Modified => StatusModified,
+        FileChangeStatus.Deleted => StatusDeleted,
+        FileChangeStatus.Renamed => StatusRenamed,
+        _ => StatusOther,
+    };
+
+    public static string StatusGlyph(FileChangeStatus status) => status switch
+    {
+        FileChangeStatus.Added => "A",
+        FileChangeStatus.Modified => "M",
+        FileChangeStatus.Deleted => "D",
+        FileChangeStatus.Renamed => "R",
+        FileChangeStatus.Copied => "C",
+        FileChangeStatus.TypeChanged => "T",
+        _ => "·",
+    };
+
+    public static string FormatPath(FileChange file)
+    {
+        if (file.Status == FileChangeStatus.Renamed && !string.IsNullOrEmpty(file.OldPath))
+            return $"{file.OldPath} → {file.Path}";
+        return file.Path;
+    }
+}
+
+/// <summary>
+/// One row in a list of file changes: a colored status badge ("A", "M", "D", …) followed by
+/// the file path. Renamed entries render as "old → new". Reused by both the commit details
+/// panel and the local changes view.
+/// </summary>
+public sealed class FileChangeRowView : MultiChildView
+{
+    private const float BadgeSize = 16f;
+
+    public FileChangeRowView(FileChange file)
+    {
+        var badge = new RectView
+        {
+            PreferredWidth = BadgeSize,
+            PreferredHeight = BadgeSize,
+            BackgroundColor = FileChangesPalette.StatusColor(file.Status),
+            BorderRadius = BorderRadiusStyle.All(3),
+            Children =
+            {
+                new TextView
+                {
+                    Text = FileChangesPalette.StatusGlyph(file.Status),
+                    TextColor = FileChangesPalette.BadgeText,
+                    FontSize = 11f,
+                    HorizontalTextAlignment = TextAlignment.Center,
+                    VerticalTextAlignment = TextAlignment.Center,
+                },
+            },
+        };
+
+        var path = new TextView
+        {
+            Text = FileChangesPalette.FormatPath(file),
+            TextColor = FileChangesPalette.RowText,
+        };
+
+        AddChildToSelf(new FlexRowView
+        {
+            Gap = 8f,
+            CrossAxisAlignment = CrossAxisAlignment.Start,
+            Children =
+            {
+                badge,
+                new FlexItem { Grow = 1, Child = path },
+            },
+        });
+    }
+}

--- a/GitGui/FileChangesSection.cs
+++ b/GitGui/FileChangesSection.cs
@@ -1,0 +1,76 @@
+using ZGF.Gui;
+using ZGF.Gui.Layouts;
+
+namespace GitGui;
+
+/// <summary>
+/// A titled list of file changes: a header bar showing "Title (count)" with a colored
+/// status-coded row per file. Reused by both the commit details panel and the local
+/// changes view. Rebuild the contents by calling <see cref="SetFiles"/>.
+/// </summary>
+public sealed class FileChangesSection : MultiChildView
+{
+    private const int HeaderPadding = 4;
+    private const int RowGap = 2;
+
+    private readonly string _title;
+    private readonly TextView _headerText;
+    private readonly ColumnView _rows;
+    private readonly TextView _emptyPlaceholder;
+
+    public FileChangesSection(string title, string emptyText = "(none)")
+    {
+        _title = title;
+        _headerText = new TextView
+        {
+            Text = FormatHeader(0),
+            TextColor = FileChangesPalette.HeaderText,
+        };
+        _rows = new ColumnView { Gap = RowGap };
+        _emptyPlaceholder = new TextView
+        {
+            Text = emptyText,
+            TextColor = FileChangesPalette.HeaderText,
+        };
+
+        var headerBar = new RectView
+        {
+            BackgroundColor = FileChangesPalette.HeaderBg,
+            BorderColor = new BorderColorStyle
+            {
+                Top = FileChangesPalette.HeaderBorder,
+                Bottom = FileChangesPalette.HeaderBorder,
+            },
+            BorderSize = new BorderSizeStyle { Top = 1, Bottom = 1 },
+            Padding = new PaddingStyle
+            {
+                Left = HeaderPadding,
+                Right = HeaderPadding,
+                Top = HeaderPadding,
+                Bottom = HeaderPadding,
+            },
+            Children = { _headerText },
+        };
+
+        AddChildToSelf(new ColumnView
+        {
+            Gap = 4,
+            Children = { headerBar, _rows },
+        });
+    }
+
+    public void SetFiles(IReadOnlyList<FileChange> files)
+    {
+        _headerText.Text = FormatHeader(files.Count);
+        _rows.Children.Clear();
+        if (files.Count == 0)
+        {
+            _rows.Children.Add(_emptyPlaceholder);
+            return;
+        }
+        foreach (var file in files)
+            _rows.Children.Add(new FileChangeRowView(file));
+    }
+
+    private string FormatHeader(int count) => $"{_title} ({count})";
+}

--- a/GitGui/GitService.cs
+++ b/GitGui/GitService.cs
@@ -169,6 +169,81 @@ public sealed class GitService : IGitService
         _ => FileChangeStatus.Unmodified,
     };
 
+    public LocalChangesSnapshot GetLocalChanges(Repo repo)
+    {
+        try
+        {
+            if (!Repository.IsValid(repo.Path))
+                return LocalChangesError(repo, "Not a git repository.");
+
+            using var lg = new Repository(repo.Path);
+            var status = lg.RetrieveStatus(new StatusOptions
+            {
+                IncludeUntracked = true,
+                RecurseUntrackedDirs = true,
+                DetectRenamesInIndex = true,
+                DetectRenamesInWorkDir = true,
+            });
+
+            var staged = new List<FileChange>();
+            var unstaged = new List<FileChange>();
+
+            foreach (var entry in status)
+            {
+                if (entry.State == FileStatus.Ignored || entry.State == FileStatus.Unaltered)
+                    continue;
+
+                var indexStatus = MapIndexStatus(entry.State);
+                if (indexStatus != null)
+                {
+                    var oldPath = entry.HeadToIndexRenameDetails?.OldFilePath;
+                    if (oldPath == entry.FilePath) oldPath = null;
+                    staged.Add(new FileChange(entry.FilePath, oldPath, indexStatus.Value));
+                }
+
+                var workStatus = MapWorkDirStatus(entry.State);
+                if (workStatus != null)
+                {
+                    var oldPath = entry.IndexToWorkDirRenameDetails?.OldFilePath;
+                    if (oldPath == entry.FilePath) oldPath = null;
+                    unstaged.Add(new FileChange(entry.FilePath, oldPath, workStatus.Value));
+                }
+            }
+
+            staged.Sort(static (a, b) => string.Compare(a.Path, b.Path, StringComparison.OrdinalIgnoreCase));
+            unstaged.Sort(static (a, b) => string.Compare(a.Path, b.Path, StringComparison.OrdinalIgnoreCase));
+
+            return new LocalChangesSnapshot(repo.Id, staged, unstaged, null);
+        }
+        catch (Exception ex)
+        {
+            return LocalChangesError(repo, ex.Message);
+        }
+    }
+
+    private static FileChangeStatus? MapIndexStatus(FileStatus state)
+    {
+        if ((state & FileStatus.NewInIndex) != 0) return FileChangeStatus.Added;
+        if ((state & FileStatus.ModifiedInIndex) != 0) return FileChangeStatus.Modified;
+        if ((state & FileStatus.DeletedFromIndex) != 0) return FileChangeStatus.Deleted;
+        if ((state & FileStatus.RenamedInIndex) != 0) return FileChangeStatus.Renamed;
+        if ((state & FileStatus.TypeChangeInIndex) != 0) return FileChangeStatus.TypeChanged;
+        return null;
+    }
+
+    private static FileChangeStatus? MapWorkDirStatus(FileStatus state)
+    {
+        if ((state & FileStatus.NewInWorkdir) != 0) return FileChangeStatus.Added;
+        if ((state & FileStatus.ModifiedInWorkdir) != 0) return FileChangeStatus.Modified;
+        if ((state & FileStatus.DeletedFromWorkdir) != 0) return FileChangeStatus.Deleted;
+        if ((state & FileStatus.RenamedInWorkdir) != 0) return FileChangeStatus.Renamed;
+        if ((state & FileStatus.TypeChangeInWorkdir) != 0) return FileChangeStatus.TypeChanged;
+        return null;
+    }
+
+    private static LocalChangesSnapshot LocalChangesError(Repo repo, string message)
+        => new(repo.Id, Array.Empty<FileChange>(), Array.Empty<FileChange>(), message);
+
     private static CommitDetails DetailsError(Repo repo, string sha, string message)
         => new(
             RepoId: repo.Id,

--- a/GitGui/IGitService.cs
+++ b/GitGui/IGitService.cs
@@ -4,4 +4,5 @@ public interface IGitService
 {
     CommitSnapshot Load(Repo repo, int cap);
     CommitDetails LoadDetails(Repo repo, string sha);
+    LocalChangesSnapshot GetLocalChanges(Repo repo);
 }

--- a/GitGui/LocalChanges.cs
+++ b/GitGui/LocalChanges.cs
@@ -1,0 +1,7 @@
+namespace GitGui;
+
+public sealed record LocalChangesSnapshot(
+    Guid RepoId,
+    IReadOnlyList<FileChange> Staged,
+    IReadOnlyList<FileChange> Unstaged,
+    string? ErrorMessage);

--- a/GitGui/LocalChangesView.cs
+++ b/GitGui/LocalChangesView.cs
@@ -1,15 +1,14 @@
 using ZGF.Gui;
 using ZGF.Gui.Layouts;
 using ZGF.Gui.Tests;
+using ZGF.Observable;
 
 namespace GitGui;
 
-internal enum LocalChangesState
+internal abstract record LocalChangesViewModel
 {
-    NoRepo,
-    Loading,
-    Loaded,
-    Error,
+    public sealed record Placeholder(string Text) : LocalChangesViewModel;
+    public sealed record Loaded(LocalChangesSnapshot Snapshot) : LocalChangesViewModel;
 }
 
 public sealed class LocalChangesView : MultiChildView
@@ -18,13 +17,14 @@ public sealed class LocalChangesView : MultiChildView
 
     private IRepoRegistry? _registry;
     private IGitService? _gitService;
+    private IUiDispatcher? _dispatcher;
     private IDisposable? _activeSubscription;
+    private IDisposable? _vmSubscription;
 
-    private LocalChangesState _state = LocalChangesState.NoRepo;
-    private LocalChangesSnapshot? _pendingSnapshot;
-    private string? _pendingErrorMessage;
+    private readonly State<LocalChangesViewModel> _viewModel = new(
+        new LocalChangesViewModel.Placeholder("Open a repository to see local changes."));
+
     private int _loadGeneration;
-    private Guid _loadingRepoId;
 
     private readonly ColumnView _content;
     private readonly ScrollPane _scrollPane;
@@ -92,26 +92,29 @@ public sealed class LocalChangesView : MultiChildView
         });
 
         Behaviors.Add(new LocalChangesScrollSyncController(_scrollPane, _vScrollBar));
-
-        ShowPlaceholder("Open a repository to see local changes.");
     }
 
     protected override void OnAttachedToContext(Context context)
     {
         _registry = context.Get<IRepoRegistry>();
         _gitService = context.Get<IGitService>();
+        _dispatcher = context.Get<IUiDispatcher>();
+        _vmSubscription = _viewModel.Subscribe(Render);
         if (_registry != null)
-        {
             _activeSubscription = _registry.Active.Subscribe(_ => StartLoadForActiveRepo());
-        }
     }
 
     protected override void OnDetachedFromContext(Context context)
     {
+        // Bump the generation so any in-flight worker's dispatcher.Post becomes a no-op.
+        _loadGeneration++;
         _activeSubscription?.Dispose();
         _activeSubscription = null;
+        _vmSubscription?.Dispose();
+        _vmSubscription = null;
         _registry = null;
         _gitService = null;
+        _dispatcher = null;
     }
 
     private void StartLoadForActiveRepo()
@@ -124,60 +127,49 @@ public sealed class LocalChangesView : MultiChildView
 
         if (active == null)
         {
-            _state = LocalChangesState.NoRepo;
-            ShowPlaceholder("Open a repository to see local changes.");
+            _viewModel.Value = new LocalChangesViewModel.Placeholder("Open a repository to see local changes.");
             return;
         }
 
-        _state = LocalChangesState.Loading;
-        _loadingRepoId = active.Id;
-        ShowPlaceholder("Loading…");
+        _viewModel.Value = new LocalChangesViewModel.Placeholder("Loading…");
 
         var repo = active;
         var service = _gitService;
+        var dispatcher = _dispatcher;
         Task.Run(() =>
         {
+            LocalChangesViewModel result;
             try
             {
                 var snap = service.GetLocalChanges(repo);
-                if (gen != Volatile.Read(ref _loadGeneration)) return;
-                Volatile.Write(ref _pendingSnapshot, snap);
+                result = snap.ErrorMessage != null
+                    ? new LocalChangesViewModel.Placeholder(snap.ErrorMessage)
+                    : new LocalChangesViewModel.Loaded(snap);
             }
             catch (Exception ex)
             {
-                if (gen != Volatile.Read(ref _loadGeneration)) return;
-                Volatile.Write(ref _pendingErrorMessage, ex.Message);
+                result = new LocalChangesViewModel.Placeholder(ex.Message);
             }
+
+            dispatcher?.Post(() =>
+            {
+                if (gen != _loadGeneration) return;
+                _viewModel.Value = result;
+            });
         });
     }
 
-    protected override void OnDrawSelf(ICanvas c)
+    private void Render(LocalChangesViewModel vm)
     {
-        PollPending();
-    }
-
-    private void PollPending()
-    {
-        var err = Interlocked.Exchange(ref _pendingErrorMessage, null);
-        if (err != null)
+        switch (vm)
         {
-            _state = LocalChangesState.Error;
-            ShowPlaceholder(err);
+            case LocalChangesViewModel.Placeholder p:
+                ShowPlaceholder(p.Text);
+                break;
+            case LocalChangesViewModel.Loaded l:
+                ShowSnapshot(l.Snapshot);
+                break;
         }
-
-        var pending = Interlocked.Exchange(ref _pendingSnapshot, null);
-        if (pending == null) return;
-        if (pending.RepoId != _loadingRepoId) return;
-
-        if (pending.ErrorMessage != null)
-        {
-            _state = LocalChangesState.Error;
-            ShowPlaceholder(pending.ErrorMessage);
-            return;
-        }
-
-        _state = LocalChangesState.Loaded;
-        ShowSnapshot(pending);
     }
 
     private void ShowPlaceholder(string text)

--- a/GitGui/LocalChangesView.cs
+++ b/GitGui/LocalChangesView.cs
@@ -44,7 +44,7 @@ public sealed class LocalChangesView : MultiChildView
         _unstagedSection = new FileChangesSection("Unstaged", emptyText: "No unstaged changes.");
 
         _content = new ColumnView { Gap = 12 };
-        var paddedContent = new RectView
+        var paddedContent = new PaddingView
         {
             Padding = new PaddingStyle { Left = Padding, Right = Padding, Top = Padding, Bottom = Padding },
             Children = { _content },

--- a/GitGui/LocalChangesView.cs
+++ b/GitGui/LocalChangesView.cs
@@ -1,24 +1,238 @@
 using ZGF.Gui;
+using ZGF.Gui.Layouts;
+using ZGF.Gui.Tests;
 
 namespace GitGui;
 
+internal enum LocalChangesState
+{
+    NoRepo,
+    Loading,
+    Loaded,
+    Error,
+}
+
 public sealed class LocalChangesView : MultiChildView
 {
+    private const int Padding = 14;
+
+    private IRepoRegistry? _registry;
+    private IGitService? _gitService;
+    private IDisposable? _activeSubscription;
+
+    private LocalChangesState _state = LocalChangesState.NoRepo;
+    private LocalChangesSnapshot? _pendingSnapshot;
+    private string? _pendingErrorMessage;
+    private int _loadGeneration;
+    private Guid _loadingRepoId;
+
+    private readonly ColumnView _content;
+    private readonly ScrollPane _scrollPane;
+    private readonly VerticalScrollBarView _vScrollBar;
+    private readonly TextView _placeholder;
+    private readonly FileChangesSection _stagedSection;
+    private readonly FileChangesSection _unstagedSection;
+
     public LocalChangesView()
     {
+        _placeholder = new TextView
+        {
+            TextColor = CommitsPalette.Placeholder,
+            HorizontalTextAlignment = TextAlignment.Center,
+        };
+        _stagedSection = new FileChangesSection("Staged", emptyText: "No staged changes.");
+        _unstagedSection = new FileChangesSection("Unstaged", emptyText: "No unstaged changes.");
+
+        _content = new ColumnView { Gap = 12 };
+        var paddedContent = new RectView
+        {
+            Padding = new PaddingStyle { Left = Padding, Right = Padding, Top = Padding, Bottom = Padding },
+            Children = { _content },
+        };
+
+        _scrollPane = new ScrollPane();
+        _scrollPane.Children.Add(paddedContent);
+        _scrollPane.Behaviors.Add(new ScrollPaneWheelController(_scrollPane));
+
+        _vScrollBar = new VerticalScrollBarView
+        {
+            TrackBackgroundColor = CommitsPalette.ScrollTrackBg,
+            TrackBorderColor = new BorderColorStyle
+            {
+                Left = CommitsPalette.ScrollTrackBorder,
+                Top = CommitsPalette.ScrollTrackBorder,
+                Right = CommitsPalette.ScrollTrackBorder,
+                Bottom = CommitsPalette.ScrollTrackBorder,
+            },
+            TrackBorderSize = new BorderSizeStyle { Left = 1 },
+        };
+        _vScrollBar.Thumb.IdleBackgroundColor = CommitsPalette.ScrollThumbBg;
+        _vScrollBar.Thumb.HoveredBackgroundColor = CommitsPalette.ScrollThumbHoverBg;
+        _vScrollBar.Thumb.BorderColor = new BorderColorStyle
+        {
+            Left = CommitsPalette.ScrollThumbBorder,
+            Top = CommitsPalette.ScrollThumbBorder,
+            Right = CommitsPalette.ScrollThumbBorder,
+            Bottom = CommitsPalette.ScrollThumbBorder,
+        };
+        _vScrollBar.Thumb.BorderSize = BorderSizeStyle.All(1);
+        _vScrollBar.Behaviors.Add(new VerticalScrollBarViewController(_vScrollBar));
+
         AddChildToSelf(new RectView
         {
             BackgroundColor = CommitsPalette.Background,
             Children =
             {
-                new TextView
+                new BorderLayoutView
                 {
-                    Text = "Local Changes — coming soon",
-                    TextColor = CommitsPalette.Placeholder,
-                    HorizontalTextAlignment = TextAlignment.Center,
-                    VerticalTextAlignment = TextAlignment.Center,
+                    Center = _scrollPane,
+                    East = _vScrollBar,
                 },
             },
         });
+
+        Behaviors.Add(new LocalChangesScrollSyncController(_scrollPane, _vScrollBar));
+
+        ShowPlaceholder("Open a repository to see local changes.");
+    }
+
+    protected override void OnAttachedToContext(Context context)
+    {
+        _registry = context.Get<IRepoRegistry>();
+        _gitService = context.Get<IGitService>();
+        if (_registry != null)
+        {
+            _activeSubscription = _registry.Active.Subscribe(_ => StartLoadForActiveRepo());
+        }
+    }
+
+    protected override void OnDetachedFromContext(Context context)
+    {
+        _activeSubscription?.Dispose();
+        _activeSubscription = null;
+        _registry = null;
+        _gitService = null;
+    }
+
+    private void StartLoadForActiveRepo()
+    {
+        if (_registry == null || _gitService == null) return;
+        var active = _registry.Active.Value;
+
+        _loadGeneration++;
+        var gen = _loadGeneration;
+
+        if (active == null)
+        {
+            _state = LocalChangesState.NoRepo;
+            ShowPlaceholder("Open a repository to see local changes.");
+            return;
+        }
+
+        _state = LocalChangesState.Loading;
+        _loadingRepoId = active.Id;
+        ShowPlaceholder("Loading…");
+
+        var repo = active;
+        var service = _gitService;
+        Task.Run(() =>
+        {
+            try
+            {
+                var snap = service.GetLocalChanges(repo);
+                if (gen != Volatile.Read(ref _loadGeneration)) return;
+                Volatile.Write(ref _pendingSnapshot, snap);
+            }
+            catch (Exception ex)
+            {
+                if (gen != Volatile.Read(ref _loadGeneration)) return;
+                Volatile.Write(ref _pendingErrorMessage, ex.Message);
+            }
+        });
+    }
+
+    protected override void OnDrawSelf(ICanvas c)
+    {
+        PollPending();
+    }
+
+    private void PollPending()
+    {
+        var err = Interlocked.Exchange(ref _pendingErrorMessage, null);
+        if (err != null)
+        {
+            _state = LocalChangesState.Error;
+            ShowPlaceholder(err);
+        }
+
+        var pending = Interlocked.Exchange(ref _pendingSnapshot, null);
+        if (pending == null) return;
+        if (pending.RepoId != _loadingRepoId) return;
+
+        if (pending.ErrorMessage != null)
+        {
+            _state = LocalChangesState.Error;
+            ShowPlaceholder(pending.ErrorMessage);
+            return;
+        }
+
+        _state = LocalChangesState.Loaded;
+        ShowSnapshot(pending);
+    }
+
+    private void ShowPlaceholder(string text)
+    {
+        _placeholder.Text = text;
+        _content.Children.Clear();
+        _content.Children.Add(_placeholder);
+        _scrollPane.ScrollToOrigin();
+    }
+
+    private void ShowSnapshot(LocalChangesSnapshot snap)
+    {
+        _stagedSection.SetFiles(snap.Staged);
+        _unstagedSection.SetFiles(snap.Unstaged);
+        _content.Children.Clear();
+        _content.Children.Add(_stagedSection);
+        _content.Children.Add(_unstagedSection);
+        _scrollPane.ScrollToOrigin();
+    }
+}
+
+internal sealed class LocalChangesScrollSyncController : KeyboardMouseController
+{
+    private const float ScrollBarThickness = 12f;
+
+    private readonly ScrollPane _pane;
+    private readonly VerticalScrollBarView _vScrollBar;
+
+    public LocalChangesScrollSyncController(ScrollPane pane, VerticalScrollBarView vScrollBar)
+    {
+        _pane = pane;
+        _vScrollBar = vScrollBar;
+    }
+
+    protected override void OnAttachedToContext(View view, Context context)
+    {
+        _pane.VerticalScrollPositionChanged += OnPaneVerticalScroll;
+        _vScrollBar.ScrollPositionChanged += OnVScrollBarScroll;
+    }
+
+    protected override void OnDetachedFromContext(View view, Context context)
+    {
+        _pane.VerticalScrollPositionChanged -= OnPaneVerticalScroll;
+        _vScrollBar.ScrollPositionChanged -= OnVScrollBarScroll;
+    }
+
+    private void OnPaneVerticalScroll(float normalized)
+    {
+        _vScrollBar.PreferredWidth = _pane.VerticalScale < 1f ? ScrollBarThickness : 0f;
+        _vScrollBar.Scale = _pane.VerticalScale;
+        _vScrollBar.SetNormalizedScrollPosition(normalized);
+    }
+
+    private void OnVScrollBarScroll(float normalized)
+    {
+        _pane.SetVerticalNormalizedScrollPosition(normalized);
     }
 }

--- a/LLMit/GuiApp.cs
+++ b/LLMit/GuiApp.cs
@@ -4,6 +4,7 @@ using ZGF.Core;
 using ZGF.Fonts;
 using ZGF.Gui;
 using ZGF.Gui.Tests;
+using ZGF.Observable;
 using static GL46;
 
 namespace LLMit;
@@ -14,6 +15,7 @@ public sealed class GuiApp : OpenGlApp
     private readonly OpenGlRenderedCanvas _canvas;
     private readonly FreeTypeFontBackend _fontBackend;
     private readonly MultiChildView _gui;
+    private readonly QueuedUiDispatcher _dispatcher;
 
     // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
     private readonly SizeCallback _windowSizeCallback;
@@ -39,10 +41,13 @@ public sealed class GuiApp : OpenGlApp
 
         _inputSystem = new GlfwInputSystem(WindowHandle, _canvas);
 
+        _dispatcher = new QueuedUiDispatcher();
+
         context.Canvas = _canvas;
 
         context.AddService(_inputSystem.InputSystem);
         context.AddService(_contextMenuManager);
+        context.AddService<IUiDispatcher>(_dispatcher);
 #if OSX
         context.AddService<IClipboard>(new OsxClipboard());
 #elif WIN
@@ -79,6 +84,7 @@ public sealed class GuiApp : OpenGlApp
 
     protected override void OnUpdate()
     {
+        _dispatcher.Drain();
         Render();
         _inputSystem.Update();
         _contextMenuManager.Update();

--- a/ZGF.Gui/Views/PaddingView.cs
+++ b/ZGF.Gui/Views/PaddingView.cs
@@ -1,0 +1,50 @@
+namespace ZGF.Gui.Layouts;
+
+/// <summary>
+/// Insets its children by a <see cref="PaddingStyle"/>. No background, border, or
+/// drawing — use this for pure spacing. Reach for <see cref="RectView"/> only when
+/// you also need to paint a box.
+/// </summary>
+public sealed class PaddingView : MultiChildView
+{
+    private PaddingStyle _padding;
+
+    public PaddingStyle Padding
+    {
+        get => _padding;
+        set => SetField(ref _padding, value);
+    }
+
+    public override float MeasureWidth()
+    {
+        var width = base.MeasureWidth();
+        width += _padding.Left + _padding.Right;
+        return width;
+    }
+
+    public override float MeasureHeight()
+    {
+        var height = base.MeasureHeight();
+        height += _padding.Top + _padding.Bottom;
+        return height;
+    }
+
+    protected override void OnLayoutChildren()
+    {
+        var position = Position;
+        var left = position.Left + _padding.Left;
+        var right = position.Right - _padding.Right;
+        var top = position.Top - _padding.Top;
+        var bottom = position.Bottom + _padding.Bottom;
+
+        foreach (var child in Children)
+        {
+            child.LeftConstraint = left;
+            child.BottomConstraint = bottom;
+            child.MinWidthConstraint = right - left;
+            child.MaxWidthConstraint = right - left;
+            child.MaxHeightConstraint = top - bottom;
+            child.LayoutSelf();
+        }
+    }
+}

--- a/ZGF.Observable/IUiDispatcher.cs
+++ b/ZGF.Observable/IUiDispatcher.cs
@@ -1,0 +1,12 @@
+namespace ZGF.Observable;
+
+/// <summary>
+/// Posts work onto the UI thread. Background workers call <see cref="Post"/>; the host
+/// app drains the queue once per frame on the UI thread. Use this instead of
+/// <see cref="System.Threading.Volatile"/>/UI-thread polling when handing values from a
+/// worker into a <see cref="State{T}"/> or other single-threaded UI state.
+/// </summary>
+public interface IUiDispatcher
+{
+    void Post(Action action);
+}

--- a/ZGF.Observable/QueuedUiDispatcher.cs
+++ b/ZGF.Observable/QueuedUiDispatcher.cs
@@ -1,0 +1,31 @@
+namespace ZGF.Observable;
+
+/// <summary>
+/// Thread-safe queue-based dispatcher. <see cref="Post"/> is safe to call from any
+/// thread; <see cref="Drain"/> must be called from the UI thread (typically once per
+/// frame). Actions posted while a drain is in progress run on the next drain, not the
+/// current one — this keeps reentrant Post calls bounded.
+/// </summary>
+public sealed class QueuedUiDispatcher : IUiDispatcher
+{
+    private readonly object _gate = new();
+    private List<Action> _queue = new();
+
+    public void Post(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        lock (_gate) _queue.Add(action);
+    }
+
+    public void Drain()
+    {
+        List<Action> batch;
+        lock (_gate)
+        {
+            if (_queue.Count == 0) return;
+            batch = _queue;
+            _queue = new List<Action>();
+        }
+        foreach (var action in batch) action();
+    }
+}


### PR DESCRIPTION
Adds GetLocalChanges to IGitService, backed by LibGit2Sharp's
RetrieveStatus mapping index/workdir flags into two FileChange lists.
LocalChangesView reuses the existing async snapshot pattern and renders
two FileChangesSection panels (Staged / Unstaged) inside a scroll pane.

The file-row and titled-section views are factored into FileChangeRowView
and FileChangesSection so CommitDetailsView shares the same styling.

https://claude.ai/code/session_01WyY5PagPLTefY9tXhPFpbj