### PR TITLE
Add cubic Bézier drawing primitive (DrawCubicBezier)

### DIFF
--- a/ZGF.Gui.Sandbox/SoftwareRenderedCanvas.cs
+++ b/ZGF.Gui.Sandbox/SoftwareRenderedCanvas.cs
@@ -121,6 +121,12 @@ public sealed class SoftwareRenderedCanvas : ICanvas
         // GPU backends only); no test currently rasterizes one.
     }
 
+    public void DrawCubicBezier(in DrawCubicBezierInputs inputs)
+    {
+        // Cubic beziers are not implemented in the software canvas yet (used by
+        // GPU backends only); no test currently rasterizes one.
+    }
+
     private RectF GetClip()
     {
         if (_clipStack.Count == 0)

--- a/ZGF.Gui.Testing/RecordingCanvas.cs
+++ b/ZGF.Gui.Testing/RecordingCanvas.cs
@@ -12,6 +12,7 @@ public sealed record RecordedBoxShadow(DrawBoxShadowInputs Inputs, int Sequence,
 public sealed record RecordedLine(DrawLineInputs Inputs, int Sequence, RectF? Clip, float Opacity, float TranslationX, float TranslationY, float ScaleX, float ScaleY) : DrawCommand(Sequence, Clip, Opacity, TranslationX, TranslationY, ScaleX, ScaleY);
 public sealed record RecordedCircle(DrawCircleInputs Inputs, int Sequence, RectF? Clip, float Opacity, float TranslationX, float TranslationY, float ScaleX, float ScaleY) : DrawCommand(Sequence, Clip, Opacity, TranslationX, TranslationY, ScaleX, ScaleY);
 public sealed record RecordedBezier(DrawBezierInputs Inputs, int Sequence, RectF? Clip, float Opacity, float TranslationX, float TranslationY, float ScaleX, float ScaleY) : DrawCommand(Sequence, Clip, Opacity, TranslationX, TranslationY, ScaleX, ScaleY);
+public sealed record RecordedCubicBezier(DrawCubicBezierInputs Inputs, int Sequence, RectF? Clip, float Opacity, float TranslationX, float TranslationY, float ScaleX, float ScaleY) : DrawCommand(Sequence, Clip, Opacity, TranslationX, TranslationY, ScaleX, ScaleY);
 
 /// <summary>Captures every draw call into typed lists with the clip in effect and a draw-order
 /// sequence index, so tests can assert what was drawn instead of pixels. Text metrics come from a
@@ -33,6 +34,7 @@ public sealed class RecordingCanvas : ICanvas
     private readonly List<RecordedLine> _lines = new();
     private readonly List<RecordedCircle> _circles = new();
     private readonly List<RecordedBezier> _beziers = new();
+    private readonly List<RecordedCubicBezier> _cubicBeziers = new();
     private readonly List<DrawCommand> _all = new();
 
     public IReadOnlyList<RecordedRect> Rects => _rects;
@@ -42,6 +44,7 @@ public sealed class RecordingCanvas : ICanvas
     public IReadOnlyList<RecordedLine> Lines => _lines;
     public IReadOnlyList<RecordedCircle> Circles => _circles;
     public IReadOnlyList<RecordedBezier> Beziers => _beziers;
+    public IReadOnlyList<RecordedCubicBezier> CubicBeziers => _cubicBeziers;
 
     public int DefaultImageWidth { get; set; }
     public int DefaultImageHeight { get; set; }
@@ -121,6 +124,15 @@ public sealed class RecordingCanvas : ICanvas
         _all.Add(cmd);
     }
 
+    public void DrawCubicBezier(in DrawCubicBezierInputs inputs)
+    {
+        var t = CurrentTranslation();
+        var s = CurrentScale();
+        var cmd = new RecordedCubicBezier(inputs, _sequence++, CurrentClip(), CurrentOpacity(), t.X, t.Y, s.X, s.Y);
+        _cubicBeziers.Add(cmd);
+        _all.Add(cmd);
+    }
+
     public bool TryGetClip(out RectF rect)
     {
         if (_clips.Count > 0)
@@ -185,6 +197,7 @@ public sealed class RecordingCanvas : ICanvas
         _lines.Clear();
         _circles.Clear();
         _beziers.Clear();
+        _cubicBeziers.Clear();
         _all.Clear();
         _clips.Clear();
         _opacities.Clear();

--- a/ZGF.Gui.Tests/CubicBezierTests.cs
+++ b/ZGF.Gui.Tests/CubicBezierTests.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ZGF.Geometry;
+using ZGF.Gui.Testing;
+
+namespace ZGF.Gui.Tests;
+
+/// <summary>The cubic bezier primitive has no SDF in the shape shader; it is flattened into
+/// quadratic pieces that the canvas strokes natively. These cover the flattening math (continuity,
+/// accuracy, adaptivity) and that colour/dash/z ride along onto each piece.</summary>
+public class CubicBezierTests
+{
+    private static DrawCubicBezierInputs Cubic(
+        PointF p0, PointF p1, PointF p2, PointF p3,
+        uint color = 0xFF112233u, uint? gradientEnd = null, float dash = 0f, float gap = 0f, int z = 4)
+        => new()
+        {
+            Start = p0, Control1 = p1, Control2 = p2, End = p3,
+            Thickness = 2f, Color = color, ZIndex = z,
+            GradientEndColor = gradientEnd, DashLength = dash, GapLength = gap,
+        };
+
+    private static List<DrawBezierInputs> Flatten(DrawCubicBezierInputs c, float flatness = CubicBezier.DefaultFlatness)
+    {
+        var output = new List<DrawBezierInputs>();
+        CubicBezier.Flatten(in c, output, flatness);
+        return output;
+    }
+
+    [Fact]
+    public void Evaluate_MatchesCubicFormula()
+    {
+        var p0 = new PointF(0, 0);
+        var p1 = new PointF(0, 10);
+        var p2 = new PointF(10, 10);
+        var p3 = new PointF(10, 0);
+        foreach (var t in new[] { 0f, 0.25f, 0.5f, 0.75f, 1f })
+        {
+            var u = 1 - t;
+            var expX = u * u * u * p0.X + 3 * u * u * t * p1.X + 3 * u * t * t * p2.X + t * t * t * p3.X;
+            var expY = u * u * u * p0.Y + 3 * u * u * t * p1.Y + 3 * u * t * t * p2.Y + t * t * t * p3.Y;
+            var got = CubicBezier.Evaluate(p0, p1, p2, p3, t);
+            Assert.Equal(expX, got.X, 4);
+            Assert.Equal(expY, got.Y, 4);
+        }
+    }
+
+    [Fact]
+    public void Flatten_StraightLine_ProducesSingleSegment()
+    {
+        // Controls collinear with the endpoints: a cubic with zero third-difference is exactly one quadratic.
+        var c = Cubic(new PointF(0, 0), new PointF(10, 0), new PointF(20, 0), new PointF(30, 0));
+        var segs = Flatten(c);
+        Assert.Single(segs);
+        Assert.Equal(0f, segs[0].Start.X, 4);
+        Assert.Equal(30f, segs[0].End.X, 4);
+    }
+
+    [Fact]
+    public void Flatten_SCurve_Subdivides_AndStaysContinuous()
+    {
+        // A genuine S needs an inflection a single quadratic can't represent, so it must subdivide.
+        var c = Cubic(new PointF(0, 0), new PointF(0, 20), new PointF(20, 0), new PointF(20, 20));
+        var segs = Flatten(c);
+
+        Assert.True(segs.Count >= 2, $"expected subdivision, got {segs.Count} segment(s)");
+
+        // Endpoints preserved, pieces chain end-to-start.
+        Assert.True(Close(segs[0].Start, c.Start));
+        Assert.True(Close(segs[^1].End, c.End));
+        for (var i = 0; i < segs.Count - 1; i++)
+            Assert.True(Close(segs[i].End, segs[i + 1].Start), $"discontinuity at join {i}");
+    }
+
+    [Fact]
+    public void Flatten_StaysWithinTolerance_OfTheTrueCubic()
+    {
+        var c = Cubic(new PointF(0, 0), new PointF(10, 40), new PointF(30, -20), new PointF(40, 20));
+        const float flatness = 0.1f;
+        var segs = Flatten(c, flatness);
+
+        // Densely sample the true cubic; every point must be near the flattened quad polyline.
+        var maxDist = 0f;
+        for (var i = 0; i <= 200; i++)
+        {
+            var pt = CubicBezier.Evaluate(c.Start, c.Control1, c.Control2, c.End, i / 200f);
+            var d = MinDistanceToSegments(pt, segs);
+            maxDist = MathF.Max(maxDist, d);
+        }
+        Assert.True(maxDist < 0.25f, $"max deviation {maxDist} exceeded tolerance");
+    }
+
+    [Fact]
+    public void Flatten_TighterTolerance_ProducesMoreSegments()
+    {
+        var c = Cubic(new PointF(0, 0), new PointF(0, 20), new PointF(20, 0), new PointF(20, 20));
+        Assert.True(Flatten(c, 0.01f).Count > Flatten(c, 1f).Count);
+    }
+
+    [Fact]
+    public void Flatten_Solid_AllSegmentsCarrySolidColor()
+    {
+        var c = Cubic(new PointF(0, 0), new PointF(0, 20), new PointF(20, 0), new PointF(20, 20), color: 0xFFABCDEFu);
+        foreach (var seg in Flatten(c))
+        {
+            Assert.Equal(0xFFABCDEFu, seg.Color);
+            Assert.Null(seg.GradientEndColor);
+        }
+    }
+
+    [Fact]
+    public void Flatten_Gradient_PreservesEndpointsAndIsContinuousAcrossJoins()
+    {
+        const uint start = 0xFF000000u;
+        const uint end = 0xFFFFFFFFu;
+        var c = Cubic(new PointF(0, 0), new PointF(0, 20), new PointF(20, 0), new PointF(20, 20), gradientEnd: end);
+        c = c with { Color = start };
+        var segs = Flatten(c);
+
+        // Global gradient endpoints land exactly on the first/last pieces.
+        Assert.Equal(start, segs[0].Color);
+        Assert.Equal(end, segs[^1].GradientEndColor);
+
+        // Each piece is a gradient, and the colour is continuous where pieces meet.
+        for (var i = 0; i < segs.Count; i++)
+        {
+            Assert.NotNull(segs[i].GradientEndColor);
+            if (i < segs.Count - 1)
+                Assert.Equal(segs[i].GradientEndColor!.Value, segs[i + 1].Color);
+        }
+    }
+
+    [Fact]
+    public void Flatten_PropagatesThicknessZIndexAndDash()
+    {
+        var c = Cubic(new PointF(0, 0), new PointF(0, 20), new PointF(20, 0), new PointF(20, 20), dash: 4f, gap: 3f, z: 7);
+        foreach (var seg in Flatten(c))
+        {
+            Assert.Equal(2f, seg.Thickness);
+            Assert.Equal(7, seg.ZIndex);
+            Assert.Equal(4f, seg.DashLength);
+            Assert.Equal(3f, seg.GapLength);
+        }
+    }
+
+    [Fact]
+    public void Flatten_OntoCanvas_StrokesContinuousQuadraticPieces()
+    {
+        var capture = new QuadCaptureCanvas();
+        var c = Cubic(new PointF(0, 0), new PointF(0, 20), new PointF(20, 0), new PointF(20, 20));
+        CubicBezier.Flatten(in c, capture);
+
+        Assert.True(capture.Quads.Count >= 2);
+        Assert.True(Close(capture.Quads[0].Start, c.Start));
+        Assert.True(Close(capture.Quads[^1].End, c.End));
+    }
+
+    [Fact]
+    public void RecordingCanvas_RecordsTheRawCubic()
+    {
+        var canvas = new RecordingCanvas();
+        var c = Cubic(new PointF(1, 2), new PointF(3, 4), new PointF(5, 6), new PointF(7, 8));
+        canvas.DrawCubicBezier(in c);
+
+        var recorded = Assert.Single(canvas.CubicBeziers);
+        Assert.Equal(new PointF(1, 2), recorded.Inputs.Start);
+        Assert.Equal(new PointF(7, 8), recorded.Inputs.End);
+    }
+
+    private static bool Close(PointF a, PointF b, float eps = 1e-3f)
+        => MathF.Abs(a.X - b.X) <= eps && MathF.Abs(a.Y - b.Y) <= eps;
+
+    private static float MinDistanceToSegments(PointF pt, List<DrawBezierInputs> segs)
+    {
+        var min = float.MaxValue;
+        foreach (var seg in segs)
+        {
+            // Sample each quadratic piece into a short polyline and take the nearest segment.
+            var prev = seg.Start;
+            for (var i = 1; i <= 16; i++)
+            {
+                var cur = QuadEval(seg.Start, seg.Control, seg.End, i / 16f);
+                min = MathF.Min(min, DistancePointToSegment(pt, prev, cur));
+                prev = cur;
+            }
+        }
+        return min;
+    }
+
+    private static PointF QuadEval(PointF a, PointF b, PointF c, float t)
+    {
+        var u = 1 - t;
+        return new PointF(
+            u * u * a.X + 2 * u * t * b.X + t * t * c.X,
+            u * u * a.Y + 2 * u * t * b.Y + t * t * c.Y);
+    }
+
+    private static float DistancePointToSegment(PointF p, PointF a, PointF b)
+    {
+        float abx = b.X - a.X, aby = b.Y - a.Y;
+        float apx = p.X - a.X, apy = p.Y - a.Y;
+        var denom = abx * abx + aby * aby;
+        var t = denom > 1e-9f ? Math.Clamp((apx * abx + apy * aby) / denom, 0f, 1f) : 0f;
+        float cx = a.X + t * abx, cy = a.Y + t * aby;
+        float dx = p.X - cx, dy = p.Y - cy;
+        return MathF.Sqrt(dx * dx + dy * dy);
+    }
+
+    /// <summary>Minimal canvas that captures the quadratic pieces a cubic flattens into.</summary>
+    private sealed class QuadCaptureCanvas : ICanvas
+    {
+        public List<DrawBezierInputs> Quads { get; } = new();
+        public void DrawBezier(in DrawBezierInputs inputs) => Quads.Add(inputs);
+
+        public void DrawRect(in DrawRectInputs inputs) { }
+        public void DrawText(in DrawTextInputs inputs) { }
+        public void DrawImage(in DrawImageInputs inputs) { }
+        public void DrawBoxShadow(in DrawBoxShadowInputs inputs) { }
+        public void DrawLine(in DrawLineInputs inputs) { }
+        public void DrawCircle(in DrawCircleInputs inputs) { }
+        public void DrawCubicBezier(in DrawCubicBezierInputs inputs) => CubicBezier.Flatten(in inputs, this);
+        public bool TryGetClip(out RectF rect) { rect = default; return false; }
+        public void PushClip(RectF rect) { }
+        public void PopClip() { }
+        public void PushOpacity(float opacity) { }
+        public void PopOpacity() { }
+        public void PushTranslation(float dx, float dy) { }
+        public void PopTranslation() { }
+        public void PushScale(float sx, float sy, float pivotX, float pivotY) { }
+        public void PopScale() { }
+        public float MeasureTextWidth(ReadOnlySpan<char> text, TextStyle style) => 0f;
+        public float MeasureTextPrefix(ReadOnlySpan<char> text, int prefixLength, TextStyle style) => 0f;
+        public float MeasureTextLineHeight(TextStyle style) => 0f;
+        public int GetImageWidth(string imageId) => 0;
+        public int GetImageHeight(string imageId) => 0;
+    }
+}

--- a/ZGF.Gui.Tests/FakeCanvas.cs
+++ b/ZGF.Gui.Tests/FakeCanvas.cs
@@ -12,6 +12,7 @@ public sealed class FakeCanvas : ICanvas
     public void DrawLine(in DrawLineInputs inputs) { }
     public void DrawCircle(in DrawCircleInputs inputs) { }
     public void DrawBezier(in DrawBezierInputs inputs) { }
+    public void DrawCubicBezier(in DrawCubicBezierInputs inputs) { }
 
     public bool TryGetClip(out RectF rect)
     {

--- a/ZGF.Gui/CubicBezier.cs
+++ b/ZGF.Gui/CubicBezier.cs
@@ -1,0 +1,143 @@
+using System.Numerics;
+using ZGF.Geometry;
+
+namespace ZGF.Gui;
+
+/// <summary>Evaluates cubic Béziers and flattens them into the quadratic segments the canvas can
+/// stroke natively. The shape shader has only a quadratic SDF, so a cubic (two control points, able
+/// to form an S with an inflection) is approximated by adaptively subdividing it — de Casteljau at
+/// the midpoint until each piece is within tolerance of a single quadratic — and emitting one
+/// <see cref="ICanvas.DrawBezier"/> per piece. Colour gradient and dashing ride along on each
+/// piece; the gradient is split across pieces by curve parameter, dashing restarts its phase per
+/// piece (negligible for thin strokes, the only place it's used).</summary>
+public static class CubicBezier
+{
+    public const float DefaultFlatness = 0.1f;
+
+    // sqrt(3)/36: the bound on how far a cubic piece deviates from its best single quadratic, per
+    // unit of the piece's third-difference vector |p0 - 3p1 + 3p2 - p3|. Each midpoint split divides
+    // that vector by 8, so subdivision converges in a handful of levels.
+    private const float ErrorPerThirdDifference = 0.0481125225f;
+    private const int MaxDepth = 10;
+
+    public static PointF Evaluate(PointF p0, PointF p1, PointF p2, PointF p3, float t)
+    {
+        var u = 1f - t;
+        var uu = u * u;
+        var tt = t * t;
+        var w0 = uu * u;
+        var w1 = 3f * uu * t;
+        var w2 = 3f * u * tt;
+        var w3 = tt * t;
+        return new PointF(
+            w0 * p0.X + w1 * p1.X + w2 * p2.X + w3 * p3.X,
+            w0 * p0.Y + w1 * p1.Y + w2 * p2.Y + w3 * p3.Y);
+    }
+
+    /// <summary>Flattens the cubic and strokes each resulting quadratic piece onto <paramref name="canvas"/>.
+    /// <paramref name="flatness"/> is the max allowed deviation, in the canvas's local coordinate units.</summary>
+    public static void Flatten(in DrawCubicBezierInputs inputs, ICanvas canvas, float flatness = DefaultFlatness)
+    {
+        var sink = new CanvasSink(canvas);
+        FlattenCore(in inputs, flatness, ref sink);
+    }
+
+    /// <summary>Flattens the cubic into quadratic pieces, appending each as a <see cref="DrawBezierInputs"/>
+    /// to <paramref name="output"/>. Exposed for tests and callers that want the pieces directly.</summary>
+    public static void Flatten(in DrawCubicBezierInputs inputs, List<DrawBezierInputs> output, float flatness = DefaultFlatness)
+    {
+        var sink = new ListSink(output);
+        FlattenCore(in inputs, flatness, ref sink);
+    }
+
+    private static void FlattenCore<TSink>(in DrawCubicBezierInputs inputs, float flatness, ref TSink sink)
+        where TSink : struct, IQuadSink
+    {
+        var p0 = new Vector2(inputs.Start.X, inputs.Start.Y);
+        var p1 = new Vector2(inputs.Control1.X, inputs.Control1.Y);
+        var p2 = new Vector2(inputs.Control2.X, inputs.Control2.Y);
+        var p3 = new Vector2(inputs.End.X, inputs.End.Y);
+        var tol = MathF.Max(flatness, 1e-4f);
+        Subdivide(in inputs, p0, p1, p2, p3, 0f, 1f, tol, 0, ref sink);
+    }
+
+    private static void Subdivide<TSink>(
+        in DrawCubicBezierInputs inputs,
+        Vector2 p0, Vector2 p1, Vector2 p2, Vector2 p3,
+        float t0, float t1, float tol, int depth, ref TSink sink)
+        where TSink : struct, IQuadSink
+    {
+        var thirdDiff = p0 - 3f * p1 + 3f * p2 - p3;
+        var error = ErrorPerThirdDifference * thirdDiff.Length();
+        if (depth >= MaxDepth || error <= tol)
+        {
+            EmitQuad(in inputs, p0, p1, p2, p3, t0, t1, ref sink);
+            return;
+        }
+
+        var a = (p0 + p1) * 0.5f;
+        var b = (p1 + p2) * 0.5f;
+        var c = (p2 + p3) * 0.5f;
+        var ab = (a + b) * 0.5f;
+        var bc = (b + c) * 0.5f;
+        var mid = (ab + bc) * 0.5f;
+        var tm = (t0 + t1) * 0.5f;
+        Subdivide(in inputs, p0, a, ab, mid, t0, tm, tol, depth + 1, ref sink);
+        Subdivide(in inputs, mid, bc, c, p3, tm, t1, tol, depth + 1, ref sink);
+    }
+
+    private static void EmitQuad<TSink>(
+        in DrawCubicBezierInputs inputs,
+        Vector2 p0, Vector2 p1, Vector2 p2, Vector2 p3,
+        float t0, float t1, ref TSink sink)
+        where TSink : struct, IQuadSink
+    {
+        // Best single-quadratic control point for this cubic piece (average of the two
+        // endpoint-tangent estimates).
+        var control = (3f * p1 + 3f * p2 - p0 - p3) * 0.25f;
+
+        var gradient = inputs.GradientEndColor.HasValue;
+        var startColor = gradient ? LerpColor(inputs.Color, inputs.GradientEndColor!.Value, t0) : inputs.Color;
+        var endColor = gradient ? LerpColor(inputs.Color, inputs.GradientEndColor!.Value, t1) : inputs.Color;
+
+        sink.Emit(new DrawBezierInputs
+        {
+            Start = new PointF(p0.X, p0.Y),
+            Control = new PointF(control.X, control.Y),
+            End = new PointF(p3.X, p3.Y),
+            Thickness = inputs.Thickness,
+            Color = startColor,
+            ZIndex = inputs.ZIndex,
+            GradientEndColor = gradient ? endColor : null,
+            DashLength = inputs.DashLength,
+            GapLength = inputs.GapLength,
+        });
+    }
+
+    private static uint LerpColor(uint a, uint b, float t)
+    {
+        t = Math.Clamp(t, 0f, 1f);
+        var inv = 1f - t;
+        var ca = (uint)(((a >> 24) & 0xFFu) * inv + ((b >> 24) & 0xFFu) * t + 0.5f);
+        var cr = (uint)(((a >> 16) & 0xFFu) * inv + ((b >> 16) & 0xFFu) * t + 0.5f);
+        var cg = (uint)(((a >> 8) & 0xFFu) * inv + ((b >> 8) & 0xFFu) * t + 0.5f);
+        var cb = (uint)((a & 0xFFu) * inv + (b & 0xFFu) * t + 0.5f);
+        return (ca << 24) | (cr << 16) | (cg << 8) | cb;
+    }
+
+    // A generic struct sink keeps the canvas path allocation-free while letting tests collect pieces.
+    private interface IQuadSink
+    {
+        void Emit(in DrawBezierInputs quad);
+    }
+
+    private readonly struct CanvasSink(ICanvas canvas) : IQuadSink
+    {
+        public void Emit(in DrawBezierInputs quad) => canvas.DrawBezier(quad);
+    }
+
+    private readonly struct ListSink(List<DrawBezierInputs> list) : IQuadSink
+    {
+        public void Emit(in DrawBezierInputs quad) => list.Add(quad);
+    }
+}

--- a/ZGF.Gui/DrawCubicBezierInputs.cs
+++ b/ZGF.Gui/DrawCubicBezierInputs.cs
@@ -1,0 +1,18 @@
+using ZGF.Geometry;
+
+namespace ZGF.Gui;
+
+public readonly struct DrawCubicBezierInputs
+{
+    public required PointF Start { get; init; }
+    public required PointF Control1 { get; init; }
+    public required PointF Control2 { get; init; }
+    public required PointF End { get; init; }
+    public required float Thickness { get; init; }
+    public required uint Color { get; init; }
+    public required int ZIndex { get; init; }
+
+    public uint? GradientEndColor { get; init; } // null = solid Color; else Color -> this along the curve (by parameter t)
+    public float DashLength { get; init; } // with GapLength > 0 enables dashing (by arc length)
+    public float GapLength { get; init; }
+}

--- a/ZGF.Gui/ICanvas.cs
+++ b/ZGF.Gui/ICanvas.cs
@@ -11,7 +11,8 @@ public interface ICanvas
     void DrawLine(in DrawLineInputs inputs);
     void DrawCircle(in DrawCircleInputs inputs);
     void DrawBezier(in DrawBezierInputs inputs);
-    
+    void DrawCubicBezier(in DrawCubicBezierInputs inputs);
+
     bool TryGetClip(out RectF rect);
     void PushClip(RectF rect);
     void PopClip();

--- a/ZGF.Gui/RenderedCanvasBase.cs
+++ b/ZGF.Gui/RenderedCanvasBase.cs
@@ -463,6 +463,16 @@ public abstract class RenderedCanvasBase : ICanvas
         });
     }
 
+    public void DrawCubicBezier(in DrawCubicBezierInputs inputs)
+    {
+        // The shape shader strokes only quadratics, so flatten the cubic into quadratic pieces
+        // (reusing DrawBezier's pipeline). Tolerance is set in device pixels then mapped back into
+        // local units, since DrawBezier re-applies the current scale to each piece.
+        var savg = (_scale.X + _scale.Y) * 0.5f;
+        var flatness = 0.2f / MathF.Max(savg, 1e-3f);
+        CubicBezier.Flatten(in inputs, this, flatness);
+    }
+
     public void DrawCircle(in DrawCircleInputs inputs)
     {
         var c = inputs.Center;


### PR DESCRIPTION
The shape shader strokes only quadratics, so DrawCubicBezier flattens a cubic into quadratic pieces (adaptive de Casteljau, error-bounded by the cubic's third difference) and reuses the existing DrawBezier pipeline — no GPU/shader/struct changes. Colour gradient is split across pieces by curve parameter; thickness/z/dash ride along.